### PR TITLE
Add PyPI mappings for setuptools-scm and python-htcondor

### DIFF
--- a/grayskull/pypi/config.yaml
+++ b/grayskull/pypi/config.yaml
@@ -314,6 +314,10 @@ sagemaker_mxnet_training:
   conda_forge: sagemaker_mxnet_container
   import_name: sagemaker_mxnet_container
 
+setuptools_scm:
+  conda_forge: setuptools-scm
+  import_name: setuptools_scm
+
 sounddevice:
   conda_forge: python-sounddevice
   import_name: sounddevice

--- a/grayskull/pypi/config.yaml
+++ b/grayskull/pypi/config.yaml
@@ -146,6 +146,10 @@ hdfs:
   conda_forge: python-hdfs
   import_name: hdfs
 
+htcondor:
+  conda_forge: python-htcondor
+  import_name: htcondor
+
 iam_units:
   conda_forge: iam-units
   import_name: iam_units

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -438,7 +438,7 @@ def test_zipp_recipe_tags_on_deps():
     assert recipe["requirements"]["host"] == [
         "pip",
         "python >=3.6",
-        "setuptools_scm >=3.4.1",
+        "setuptools-scm >=3.4.1",
     ]
 
 
@@ -467,8 +467,8 @@ def test_get_test_entry_points():
 
 def test_importlib_metadata_two_setuptools_scm():
     recipe = PyPi(name="importlib-metadata", version="1.5.0")
-    assert "setuptools_scm" in recipe["requirements"]["host"]
-    assert "setuptools-scm" not in recipe["requirements"]["host"]
+    assert "setuptools-scm" in recipe["requirements"]["host"]
+    assert "setuptools_scm" not in recipe["requirements"]["host"]
     assert recipe["about"]["license"] == "Apache-2.0"
 
 


### PR DESCRIPTION
This PR adds PyPI mappings for a couple of packages I've seen with naming quirks lately.

I hope this sort of change proposal is appropriate.