### PR TITLE
generic message

### DIFF
--- a/grayskull/__main__.py
+++ b/grayskull/__main__.py
@@ -128,9 +128,7 @@ def main(args=None):
                 is_strict_cf=args.is_strict_conda_forge,
             )
         except requests.exceptions.HTTPError as err:
-            print_msg(
-                f"{Fore.RED}Package seems to be missing.\nException: {err}\n\n"
-            )
+            print_msg(f"{Fore.RED}Package seems to be missing.\nException: {err}\n\n")
             continue
         recipe.generate_recipe(args.output, maintainers=args.maintainers)
         print_msg(

--- a/grayskull/__main__.py
+++ b/grayskull/__main__.py
@@ -129,7 +129,7 @@ def main(args=None):
             )
         except requests.exceptions.HTTPError as err:
             print_msg(
-                f"{Fore.RED}Package seems to be missing on pypi.\nException: {err}\n\n"
+                f"{Fore.RED}Package seems to be missing.\nException: {err}\n\n"
             )
             continue
         recipe.generate_recipe(args.output, maintainers=args.maintainers)

--- a/grayskull/pypi/pypi.py
+++ b/grayskull/pypi/pypi.py
@@ -809,7 +809,7 @@ class PyPi(AbstractRecipeModel):
         metadata = requests.get(url=url_pypi, timeout=5)
         if metadata.status_code != 200:
             raise requests.HTTPError(
-                f"It was not possible to recover PyPi metadata for {name}.\n"
+                f"It was not possible to recover package metadata for {name}.\n"
                 f"Error code: {metadata.status_code}"
             )
 

--- a/tests/cli/test_cli_cmds.py
+++ b/tests/cli/test_cli_cmds.py
@@ -46,8 +46,8 @@ def test_msg_missing_pkg_pypi(capsys):
     main(["pypi", "NOT_A_PACKAGE_123123123"])
     captured = capsys.readouterr()
     assert (
-        "Package seems to be missing on pypi."
-        "\nException: It was not possible to recover PyPi metadata"
+        "Package seems to be missing."
+        "\nException: It was not possible to recover package metadata"
         " for NOT_A_PACKAGE_123123123.\n"
         "Error code: 404" in captured.out
     )


### PR DESCRIPTION
Now that grayskull supports both pypi and github as sources for python packages we need more "generic messages"

I'm not sure if this is OK but I want to start the conversation. Also, it is odd to issue the command:

```
grayskull pypi gh-repo
```

Maybe we could rename that to:

```
grayskull python any-source
```

or short-circuits to `grayskull gh` and `grayskull pypi` if that makes sense.