### PR TITLE
Fix generic_py_ver_to with compatible release

### DIFF
--- a/grayskull/config.py
+++ b/grayskull/config.py
@@ -78,6 +78,8 @@ class Configuration:
         for op, major, minor in req_python:
             if op == "=":
                 op = "=="
+            elif op == "~=":
+                op = ">="
             if not minor:
                 minor = 0
             for sup_py, is_enabled in py_ver_enabled.items():

--- a/grayskull/strategy/py_base.py
+++ b/grayskull/strategy/py_base.py
@@ -142,7 +142,7 @@ def generic_py_ver_to(
     if not metadata.get("requires_python"):
         return None
     req_python = re.findall(
-        r"([><=!]+)\s*(\d+)(?:\.(\d+))?",
+        r"([~><=!]+)\s*(\d+)(?:\.(\d+))?",
         metadata["requires_python"],
     )
     if not req_python:

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -159,6 +159,7 @@ def test_get_selector():
         (">2.7", "2k", "<36"),
         ("<3", "3k", "skip"),
         ("!=3.7", "==37", "==37"),
+        ("~=3.7", "<37", "<37"),
     ],
 )
 def test_py_version_to_selector(requires_python, exp_selector, ex_cf, recipe_config):
@@ -191,6 +192,7 @@ def test_py_version_to_selector(requires_python, exp_selector, ex_cf, recipe_con
         (">2.7", ">=3.6", ">=3.6"),
         ("<3", "<3.0", "skip"),
         ("!=3.7", "!=3.7", "!=3.7"),
+        ("~=3.7", ">=3.7", ">=3.7"),
     ],
 )
 def test_py_version_to_limit_python(requires_python, exp_limit, ex_cf, recipe_config):
@@ -528,9 +530,13 @@ def test_zipp_recipe_tags_on_deps():
     ]
 
 
-def test_generic_py_ver_to():
+@pytest.mark.parametrize(
+    "requires_python, expected",
+    [(">=3.5, <3.8", ">=3.5,<3.8"), (">=3.7", ">=3.7"), ("~=3.6", ">=3.6")],
+)
+def test_generic_py_ver_to(requires_python, expected):
     config = Configuration(name="abc")
-    assert generic_py_ver_to({"requires_python": ">=3.5, <3.8"}, config) == ">=3.5,<3.8"
+    assert generic_py_ver_to({"requires_python": requires_python}, config) == expected
 
 
 def test_botocore_recipe_license_name():
@@ -849,7 +855,7 @@ def test_ensure_pep440():
 
 def test_pep440_recipe():
     recipe = create_python_recipe("codalab=0.5.26", is_strict_cf=False)[0]
-    assert recipe["requirements"]["host"] == ["pip", "python >=3.6,<3.7"]
+    assert recipe["requirements"]["host"] == ["pip", "python >=3.6"]
 
 
 def test_pep440_in_recipe_pypi():


### PR DESCRIPTION
This is more a workaround as it's not really correct.
I convert `~=3.6` to `>=3.6`, instead of `>=3.6,<4` (or `>=3.6,==3.*`).

For python versions, we should always have major.minor specified as compatible release and I'm not sure we want to force the upper bound on the major version in conda recipes. At least not for Python 4.
The python 2/3 case was different but... I hope we can start to not care about Python 2...

What do you think?
Is this good enough? Or should we try to do the correct thing?

Fix #290