### PR TITLE
Fix local sdist source

### DIFF
--- a/grayskull/strategy/py_base.py
+++ b/grayskull/strategy/py_base.py
@@ -681,7 +681,7 @@ def get_sdist_metadata(
         metadata["source"] = {"url": sdist_url, "sha256": sha256_checksum(path_pkg)}
     if config.from_local_sdist:
         metadata["source"] = {
-            "path": str(path_pkg),
+            "url": f"file://{path_pkg}",
             "sha256": sha256_checksum(path_pkg),
         }
 

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -859,7 +859,7 @@ def test_pep440_in_recipe_pypi():
 
 def test_create_recipe_from_local_sdist(pkg_pytest):
     recipe = create_python_recipe(pkg_pytest, from_local_sdist=True)[0]
-    assert recipe["source"]["path"] == pkg_pytest
+    assert recipe["source"]["url"] == f"file://{pkg_pytest}"
     assert recipe["about"]["home"] == "https://docs.pytest.org/en/latest/"
     assert recipe["about"]["summary"] == "pytest: simple powerful testing with Python"
     assert recipe["about"]["license"] == "MIT"


### PR DESCRIPTION
For local sdist archive, source shall be url and not path.
path is only for directories.

I don't know how I missed that...