### PR TITLE
Add python-symengine to quirks

### DIFF
--- a/grayskull/strategy/config.yaml
+++ b/grayskull/strategy/config.yaml
@@ -314,6 +314,10 @@ python-qnotifications:
   conda_forge: qnotifications
   import_name: QNotifications
 
+symengine:
+  conda_forge: python-symengine
+  import_name: symengine
+
 quantum-grove:
   conda_forge: grove
   import_name: grove


### PR DESCRIPTION
Conda-forge also has symengine but that is not the one on PyPI.

Ref: https://github.com/conda-forge/python-symengine-feedstock links to https://github.com/symengine/symengine.py which has the following install instructions: `pip install symengine --user`

Showed up in https://github.com/conda-forge/staged-recipes/pull/18400