### PR TITLE
Update pre-commit config and run black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 exclude: docs
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
     -   id: black
         args: [--safe, --quiet]
 -   repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.0
+    rev: v1.12.1
     hooks:
     -   id: blacken-docs
-        additional_dependencies: [black==21.12b0]
+        additional_dependencies: [black==22.3.0]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:

--- a/tests/base/test_track_packages.py
+++ b/tests/base/test_track_packages.py
@@ -125,20 +125,14 @@ def test_solve_version_delimiter():
 
 
 def test_version_solver():
-    assert (
-        _version_solver(
-            [(">=", "1.5.0"), ("<", "1.8.0")],
-            ConfigPkg("foo", delimiter_min="1.0.0", delimiter_max="2.0.0"),
-        )
-        == [">=1.5.0", "<1.8.0"]
-    )
-    assert (
-        _version_solver(
-            [(">", "0.5.0"), ("<=", "1.8.0")],
-            ConfigPkg("foo", delimiter_min="1.0.0", delimiter_max="2.0.0"),
-        )
-        == [">=1.0.0", "<=1.8.0"]
-    )
+    assert _version_solver(
+        [(">=", "1.5.0"), ("<", "1.8.0")],
+        ConfigPkg("foo", delimiter_min="1.0.0", delimiter_max="2.0.0"),
+    ) == [">=1.5.0", "<1.8.0"]
+    assert _version_solver(
+        [(">", "0.5.0"), ("<=", "1.8.0")],
+        ConfigPkg("foo", delimiter_min="1.0.0", delimiter_max="2.0.0"),
+    ) == [">=1.0.0", "<=1.8.0"]
 
 
 def test_solve_pkg_name(path_example):

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -125,17 +125,14 @@ def test_get_extra_from_requires_dist():
 def test_get_all_selectors_pypi(recipe_config):
     _, config = recipe_config
     config.version = "5.3.1"
-    assert (
-        get_all_selectors_pypi(
-            [
-                ("(", "sys_platform", "==", "win32", "", "and"),
-                ("", "python_version", "==", "2.7", ")", "and"),
-                ("", "extra", "==", "socks", "", ""),
-            ],
-            config,
-        )
-        == ["(", "win", "and", "py==27", ")"]
-    )
+    assert get_all_selectors_pypi(
+        [
+            ("(", "sys_platform", "==", "win32", "", "and"),
+            ("", "python_version", "==", "2.7", ")", "and"),
+            ("", "extra", "==", "socks", "", ""),
+        ],
+        config,
+    ) == ["(", "win", "and", "py==27", ")"]
 
 
 def test_get_selector():
@@ -338,58 +335,46 @@ def test_get_entry_points_from_sdist():
         {"entry_points": {"gui_scripts": ["gui_scripts=entrypoints"]}}
     ) == ["gui_scripts=entrypoints"]
 
-    assert (
-        sorted(
-            get_entry_points_from_sdist(
-                {
-                    "entry_points": {
-                        "gui_scripts": ["gui_scripts=entrypoints"],
-                        "console_scripts": ["console_scripts=entrypoints"],
-                    }
+    assert sorted(
+        get_entry_points_from_sdist(
+            {
+                "entry_points": {
+                    "gui_scripts": ["gui_scripts=entrypoints"],
+                    "console_scripts": ["console_scripts=entrypoints"],
                 }
-            )
+            }
         )
-        == sorted(["gui_scripts=entrypoints", "console_scripts=entrypoints"])
-    )
-    assert (
-        sorted(
-            get_entry_points_from_sdist(
-                {
-                    "entry_points": {
-                        "gui_scripts": None,
-                        "console_scripts": "console_scripts=entrypoints",
-                    }
+    ) == sorted(["gui_scripts=entrypoints", "console_scripts=entrypoints"])
+    assert sorted(
+        get_entry_points_from_sdist(
+            {
+                "entry_points": {
+                    "gui_scripts": None,
+                    "console_scripts": "console_scripts=entrypoints",
                 }
-            )
+            }
         )
-        == sorted(["console_scripts=entrypoints"])
-    )
-    assert (
-        sorted(
-            get_entry_points_from_sdist(
-                {
-                    "entry_points": {
-                        "gui_scripts": None,
-                        "console_scripts": "console_scripts=entrypoints\nfoo=bar.main",
-                    }
+    ) == sorted(["console_scripts=entrypoints"])
+    assert sorted(
+        get_entry_points_from_sdist(
+            {
+                "entry_points": {
+                    "gui_scripts": None,
+                    "console_scripts": "console_scripts=entrypoints\nfoo=bar.main",
                 }
-            )
+            }
         )
-        == sorted(["console_scripts=entrypoints", "foo=bar.main"])
-    )
-    assert (
-        sorted(
-            get_entry_points_from_sdist(
-                {
-                    "entry_points": {
-                        "gui_scripts": "gui_scripts=entrypoints",
-                        "console_scripts": None,
-                    }
+    ) == sorted(["console_scripts=entrypoints", "foo=bar.main"])
+    assert sorted(
+        get_entry_points_from_sdist(
+            {
+                "entry_points": {
+                    "gui_scripts": "gui_scripts=entrypoints",
+                    "console_scripts": None,
                 }
-            )
+            }
         )
-        == sorted(["gui_scripts=entrypoints"])
-    )
+    ) == sorted(["gui_scripts=entrypoints"])
 
 
 @pytest.mark.parametrize(
@@ -812,41 +797,35 @@ def test_add_python_min_to_strict_conda_forge():
 
 
 def test_get_test_imports_clean_modules():
-    assert (
-        get_test_imports(
-            {
-                "packages": [
-                    "_pytest",
-                    "tests",
-                    "test",
-                    "_pytest._code",
-                    "_pytest._io",
-                    "_pytest.assertion",
-                    "_pytest.config",
-                    "_pytest.mark",
-                    "pytest",
-                    "pytest.foo",
-                    "zar",
-                ]
-            }
-        )
-        == ["pytest", "zar"]
-    )
-    assert (
-        get_test_imports(
-            {
-                "packages": [
-                    "_pytest",
-                    "_pytest._code",
-                    "_pytest._io",
-                    "_pytest.assertion",
-                    "_pytest.config",
-                    "_pytest.mark",
-                ]
-            }
-        )
-        == ["_pytest", "_pytest._code"]
-    )
+    assert get_test_imports(
+        {
+            "packages": [
+                "_pytest",
+                "tests",
+                "test",
+                "_pytest._code",
+                "_pytest._io",
+                "_pytest.assertion",
+                "_pytest.config",
+                "_pytest.mark",
+                "pytest",
+                "pytest.foo",
+                "zar",
+            ]
+        }
+    ) == ["pytest", "zar"]
+    assert get_test_imports(
+        {
+            "packages": [
+                "_pytest",
+                "_pytest._code",
+                "_pytest._io",
+                "_pytest.assertion",
+                "_pytest.config",
+                "_pytest.mark",
+            ]
+        }
+    ) == ["_pytest", "_pytest._code"]
 
 
 def test_ensure_pep440():


### PR DESCRIPTION
I noticed in PR #314 that pre-commit failed: https://github.com/conda-incubator/grayskull/runs/5850605951?check_suite_focus=true

This is a [known issue](https://github.com/psf/black/issues/2976) with latest version of click and black.
It was fixed in black 22.3.0.

I updated pre-commit config and ran the new version of black.