### PR TITLE
Handle exception in get_opensource_license_data

### DIFF
--- a/grayskull/license/discovery.py
+++ b/grayskull/license/discovery.py
@@ -151,7 +151,10 @@ def get_opensource_license(license_spdx: str) -> dict:
 
 @lru_cache(maxsize=10)
 def get_opensource_license_data() -> List:
-    response = requests.get(url="https://api.opensource.org/licenses/", timeout=5)
+    try:
+        response = requests.get(url="https://api.opensource.org/licenses/", timeout=5)
+    except requests.exceptions.RequestException:
+        return []
     if response.status_code != 200:
         return []
     return response.json()


### PR DESCRIPTION
Accessing https://api.opensource.org currently raises a ConnectionError due to DNS issue,
making grayskull to crash:

```
  File "/grayskull/lib/python3.9/site-packages/grayskull/license/discovery.py", line 154, in get_opensource_license_data
    response = requests.get(url="https://api.opensource.org/licenses/", timeout=5)
  File "/grayskull/lib/python3.9/site-packages/requests/api.py", line 75, in get
    return request('get', url, params=params, **kwargs)
  File "/grayskull/lib/python3.9/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/grayskull/lib/python3.9/site-packages/requests/sessions.py", line 529, in request
    resp = self.send(prep, **send_kwargs)
  File "/grayskull/lib/python3.9/site-packages/requests/sessions.py", line 645, in send
    r = adapter.send(request, **kwargs)
  File "/grayskull/lib/python3.9/site-packages/requests/adapters.py", line 519, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='api.opensource.org', port=443): Max retries exceeded with url: /licenses/ (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f5937c8ca90>: Failed to establish a new connection: [Errno -2] Name or service not known'))
```

See https://github.com/OpenSourceOrg/licenses/issues/80

Often data from spdx are enough to match the license.
grayskull shouldn't crash on this.