### PR TITLE
Add support for optional dependencies

### DIFF
--- a/grayskull/__main__.py
+++ b/grayskull/__main__.py
@@ -137,6 +137,37 @@ def main(args=None):
         dest="github_release_tag",
         help="If tag is specified, grayskull will build from release tag",
     )
+    pypi_cmds.add_argument(
+        "--extras-require-all",
+        default=False,
+        action="store_true",
+        dest="extras_require_all",
+        help="Include all extra requirements.",
+    )
+    pypi_cmds.add_argument(
+        "--extras-require-include",
+        default=tuple(),
+        type=str,
+        nargs="*",
+        dest="extras_require_include",
+        help="Include these extra requirements.",
+    )
+    pypi_cmds.add_argument(
+        "--extras-require-exclude",
+        default=tuple(),
+        type=str,
+        nargs="*",
+        dest="extras_require_exclude",
+        help="Exclude these extra requirements (overrides include).",
+    )
+    pypi_cmds.add_argument(
+        "--extras-require-split",
+        default=False,
+        action="store_true",
+        dest="extras_require_split",
+        help="Create a separate conda package for each extra requirements."
+        " Ignored when no extra requirements are selected.",
+    )
 
     args = parser.parse_args(args)
 
@@ -190,6 +221,10 @@ def generate_recipes_from_list(list_pkgs, args):
                 from_local_sdist=from_local_sdist,
                 extras_require_test=args.extras_require_test,
                 github_release_tag=args.github_release_tag,
+                extras_require_include=tuple(args.extras_require_include),
+                extras_require_exclude=tuple(args.extras_require_exclude),
+                extras_require_all=args.extras_require_all,
+                extras_require_split=args.extras_require_split,
             )
         except requests.exceptions.HTTPError as err:
             print_msg(f"{Fore.RED}Package seems to be missing.\nException: {err}\n\n")

--- a/grayskull/config.py
+++ b/grayskull/config.py
@@ -41,6 +41,10 @@ class Configuration:
     missing_deps: set = field(default_factory=set)
     extras_require_test: Optional[str] = None
     github_release_tag: Optional[str] = None
+    extras_require_include: Tuple[str] = tuple()
+    extras_require_exclude: Tuple[str] = tuple()
+    extras_require_all: bool = False
+    extras_require_split: bool = False
 
     def get_oldest_py3_version(self, list_py_ver: List[PyVer]) -> PyVer:
         list_py_ver = sorted(list_py_ver)

--- a/grayskull/strategy/py_base.py
+++ b/grayskull/strategy/py_base.py
@@ -586,21 +586,6 @@ def get_test_imports(metadata: dict, default: Optional[str] = None) -> List:
     return result
 
 
-def get_test_requirements(metadata: Dict, extras_require_test: Optional[str]) -> List:
-    """Extract test requirements from metadata
-
-    :param metadata:
-    :param extras_require_test: `extras_require` option for test requirements
-    :return: list of test requirements
-    """
-    if not extras_require_test:
-        return list()
-    try:
-        return metadata["extras_require"][extras_require_test]
-    except KeyError:
-        return list()
-
-
 def get_entry_points_from_sdist(sdist_metadata: dict) -> List:
     """Extract entry points from sdist metadata
 

--- a/tests/cli/test_cli_cmds.py
+++ b/tests/cli/test_cli_cmds.py
@@ -81,6 +81,10 @@ def test_change_pypi_url(mocker):
         from_local_sdist=False,
         extras_require_test=None,
         github_release_tag=None,
+        extras_require_include=tuple(),
+        extras_require_exclude=tuple(),
+        extras_require_all=False,
+        extras_require_split=False,
     )
 
 


### PR DESCRIPTION
Closes #150

Add support for optional dependencies. For example `pip install mypackage[option1,option2]`.

Already existing command line parameters:

```
  --extras-require-test EXTRAS_REQUIRE_TEST
                        Extra requirements to run tests.
```

New command line parameters:
```
  --extras-require-all  Include all extra requirements.
  --extras-require-include [EXTRAS_REQUIRE_INCLUDE [EXTRAS_REQUIRE_INCLUDE ...]]
                        Include these extra requirements.
  --extras-require-exclude [EXTRAS_REQUIRE_EXCLUDE [EXTRAS_REQUIRE_EXCLUDE ...]]
                        Exclude these extra requirements (overrides include).
  --extras-require-split
                        Create a separate conda package for each extra requirements.
                        Ignored when no extra requirements are selected.
```

There are two situations when `--extras-require-all ` or `--extras-require` is used:

1. Without `--extras-require-split`: the optional dependencies are simply added to the `requirements` of the conda package
2. With `--extras-require-split`: create an extra conda package for each option

The later is achieved by a meta package with different outputs (see for example [matplotlib)](https://github.com/conda-forge/matplotlib-feedstock/blob/main/recipe/meta.yaml)

| pypi                                   | conda                                             |
|----------------------------------------|---------------------------------------------------|
| pip install mypackage                  | conda install mypackage                           |
| pip install mypackage[option1]         | conda install mypackage-option1                   |
| pip install mypackage[option2]         | conda install mypackage-option2                   |
| pip install mypackage[option1,option2] | conda install mypackage-option1 mypackage-option2 |

The recipe of the meta package looks like this

```yaml
{% set name = "mypackage" %}
{% set version = "1.0.0" %}

package:
  name: {{ name|lower }}-meta
  version: {{ version }}

source:
  ...

outputs:
  - name: {{ name|lower }}
    build:
      ...
    requirements:
      ...
    test:
      ...
  - name: {{ name|lower }}-option1
    build:
      ...
    requirements:
      run:
        {{ name|lower }}
        ...
      ...
    test:
      ...
  - name: {{ name|lower }}-option2
    build:
      ...
      run:
        {{ name|lower }}
        ...
      ...
    test:
      ...

about:
  ...

extra:
  ...
```
