### PR TITLE
robust way of checking whether a package is in a list of requirements

### DIFF
--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -31,6 +31,7 @@ from grayskull.strategy.py_base import (
     get_test_entry_points,
     get_test_imports,
     get_test_requirements,
+    package_in_requirements,
     parse_extra_metadata_to_selector,
     py_version_to_limit_python,
     py_version_to_selector,
@@ -392,7 +393,7 @@ def get_metadata(recipe, config) -> dict:
     test_requirements.extend(
         get_test_requirements(metadata, config.extras_require_test)
     )
-    if any("pytest" in req for req in test_requirements):
+    if package_in_requirements("pytest", test_requirements):
         for module in test_imports:
             test_commands.append("pytest --pyargs " + module)
     test_commands.extend(get_test_entry_points(metadata.get("entry_points", [])))

--- a/grayskull/utils.py
+++ b/grayskull/utils.py
@@ -9,7 +9,7 @@ from functools import lru_cache
 from glob import glob
 from pathlib import Path
 from shutil import copyfile
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Sequence, Union
 
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
@@ -251,3 +251,29 @@ def merge_dict_of_lists_item(destination: dict, add: dict, key: str) -> None:
         merge_list_item(sub_destination, sub_add, sub_key)
     if sub_destination:
         destination[key] = sub_destination
+
+
+def package_in_requirements(package: str, requirements: Sequence[str]) -> bool:
+    return any(
+        is_requirement_of_package(package, requirement) for requirement in requirements
+    )
+
+
+def remove_package_from_requirements(
+    package: str, requirements: Sequence[str]
+) -> Sequence[str]:
+    return [
+        requirement
+        for requirement in requirements
+        if not is_requirement_of_package(package, requirement)
+    ]
+
+
+def is_requirement_of_package(package: str, requirement: str) -> bool:
+    """For example "setuptools_scm[toml] >= 3.4.1" is a
+    requirement expression of the package "setuptools-scm".
+    """
+    package = package.replace("-", "_")
+    requirement = requirement.replace("-", "_")
+    pattern = rf"^{package}[^_\w]|^{package}$"
+    return bool(re.match(pattern, requirement))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,8 @@ from grayskull.utils import (
     merge_dict_of_lists_item,
     merge_list_item,
     origin_is_local_sdist,
+    package_in_requirements,
+    remove_package_from_requirements,
 )
 
 
@@ -118,3 +120,35 @@ def test_merge_dict_of_lists_item():
             sub_key: set(lst) for sub_key, lst in destination[key].items()
         }
     assert destination == {"name": {"sub_name": {1, 2}}}
+
+
+@pytest.mark.parametrize(
+    "requirements",
+    [["setuptools_scm"], ["setuptools-scm"], ["setuptools_scm[toml] >= 3.4.1"]],
+)
+def test_package_in_requirements(requirements):
+    assert package_in_requirements("setuptools_scm", requirements)
+    assert package_in_requirements("setuptools-scm", requirements)
+    assert not package_in_requirements("setuptools", requirements)
+
+
+@pytest.mark.parametrize(
+    "requirements",
+    [["setuptools_scm"], ["setuptools-scm"], ["setuptools_scm[toml] >= 3.4.1"]],
+)
+def test_remove_package_from_requirements(requirements):
+    reduced = remove_package_from_requirements("setuptools_scm", requirements)
+    assert len(reduced) == len(requirements) - 1
+    reduced = remove_package_from_requirements("setuptools-scm", requirements)
+    assert len(reduced) == len(requirements) - 1
+    reduced = remove_package_from_requirements("setuptools", requirements)
+    assert len(reduced) == len(requirements)
+
+
+def test_remove_package_from_requirements_corner_cases():
+    reduced = remove_package_from_requirements("setuptools_scm", [])
+    assert not reduced
+    reduced = remove_package_from_requirements("", ["setuptools_scm"])
+    assert reduced == ["setuptools_scm"]
+    reduced = remove_package_from_requirements("", [])
+    assert not reduced


### PR DESCRIPTION
Closes #343

By introducing the robust check, some tests related to `setuptools-scm` fail. I don't know what the expected result should be. In the code `setuptools-scm` is removed from the requirements but in the tests it is expected to be there.