### PR TITLE
From GitHub tag

### DIFF
--- a/grayskull/__main__.py
+++ b/grayskull/__main__.py
@@ -130,6 +130,13 @@ def main(args=None):
         dest="extras_require_test",
         help="Extra requirements to run tests.",
     )
+    pypi_cmds.add_argument(
+        "--tag",
+        "-t",
+        default=None,
+        dest="github_release_tag",
+        help="If tag is specified, grayskull will build from given release tag, rather than latest.",
+    )
 
     args = parser.parse_args(args)
 
@@ -182,6 +189,7 @@ def generate_recipes_from_list(list_pkgs, args):
                 sections_populate=args.sections_populate,
                 from_local_sdist=from_local_sdist,
                 extras_require_test=args.extras_require_test,
+                github_release_tag=args.github_release_tag,
             )
         except requests.exceptions.HTTPError as err:
             print_msg(f"{Fore.RED}Package seems to be missing.\nException: {err}\n\n")

--- a/grayskull/__main__.py
+++ b/grayskull/__main__.py
@@ -135,7 +135,7 @@ def main(args=None):
         "-t",
         default=None,
         dest="github_release_tag",
-        help="If tag is specified, grayskull will build from given release tag, rather than latest.",
+        help="If tag is specified, grayskull will build from release tag",
     )
 
     args = parser.parse_args(args)

--- a/grayskull/base/github.py
+++ b/grayskull/base/github.py
@@ -25,14 +25,14 @@ def fetch_latest_metadata_from_github_repo(git_url):
 
 def verify_github_repo_tag(git_url, tag):
     """partial clone of fetch_latest_metadata..()
-       attempts to pull repo metadata instead from git/refs/tags/{tag} 
-       if successful it tries to match refs tag with requested tag
-       
-       partial matches return a list of possible refs - 
-       e.g. "v.1.8.2rc" vs 1.8.2rc1, 1.8.2rc2
-       handled with a printed list of matches and exits
-       
-       returns True when requested tag is found where expected
+    attempts to pull repo metadata instead from git/refs/tags/{tag}
+    if successful it tries to match refs tag with requested tag
+
+    partial matches return a list of possible refs -
+    e.g. "v.1.8.2rc" vs 1.8.2rc1, 1.8.2rc2
+    handled with a printed list of matches and exits
+
+    returns True when requested tag is found where expected
     """
     url_parts = urlparse(git_url)
     netloc = "api.github.com"
@@ -43,7 +43,8 @@ def verify_github_repo_tag(git_url, tag):
     response.raise_for_status()
     if isinstance(response.json(), list):
         print_msg(
-            f"Found multiple tags matching requested {tag}, possible matches: {[i['ref'].split('/')[-1] for i in response.json()]}"
+            f"""Found multiple tags matching requested {tag}, possible
+            matches: {[i['ref'].split('/')[-1] for i in response.json()]}"""
         )
         return False
     elif response.json()["ref"].split("/")[-1] == tag:

--- a/grayskull/base/github.py
+++ b/grayskull/base/github.py
@@ -23,6 +23,37 @@ def fetch_latest_metadata_from_github_repo(git_url):
     return response.json()
 
 
+def verify_github_repo_tag(git_url, tag):
+    """partial clone of fetch_latest_metadata..()
+       attempts to pull repo metadata instead from git/refs/tags/{tag} 
+       if successful it tries to match refs tag with requested tag
+       
+       partial matches return a list of possible refs - 
+       e.g. "v.1.8.2rc" vs 1.8.2rc1, 1.8.2rc2
+       handled with a printed list of matches and exits
+       
+       returns True when requested tag is found where expected
+    """
+    url_parts = urlparse(git_url)
+    netloc = "api.github.com"
+    path = f"/repos{url_parts.path}/git/refs/tags/{tag}"
+    api_parts = url_parts.scheme, netloc, path, *url_parts[3:]
+    api_url = urlunparse(api_parts)
+    response = requests.get(api_url)
+    response.raise_for_status()
+    if isinstance(response.json(), list):
+        print_msg(
+            f"Found multiple tags matching requested {tag}, possible matches: {[i['ref'].split('/')[-1] for i in response.json()]}"
+        )
+        return False
+    elif response.json()["ref"].split("/")[-1] == tag:
+        return True
+    else:
+        # edge cases 'handled' here
+        print_msg("Unable to match requested tag to github ref tag")
+        return False
+
+
 def get_latest_version_of_github_repo(git_url: str) -> str:
     """get the latest version of the github repository using github api"""
     return fetch_latest_metadata_from_github_repo(git_url)["tag_name"]
@@ -45,7 +76,9 @@ def get_most_similar_tag_in_repo(git_url: str, query: str) -> str:
     return most_similar
 
 
-def handle_gh_version(name: str, version: str, url: str) -> Tuple[Union[str, Any], Any]:
+def handle_gh_version(
+    name: str, version: str, url: str, tag: str
+) -> Tuple[Union[str, Any], Any, Any]:
     """Method responsible for handling the version of the GitHub package.
     If version is specified, gets the closest tag in the repo.
     If not, gets the latest version.
@@ -55,6 +88,13 @@ def handle_gh_version(name: str, version: str, url: str) -> Tuple[Union[str, Any
         # try get the tag with the most similar name to the requested version
         version_tag = get_most_similar_tag_in_repo(url, version)
         log.info(f"Closest git reference to `{version}` is `{version_tag}`.")
+    elif tag:
+        # try get the tag with the most similar name to the requested release tag
+        if verify_github_repo_tag(url, tag):
+            version_tag = tag
+            version = version_tag
+        else:
+            exit()
     else:
         version_tag = get_latest_version_of_github_repo(url)
         log.info(

--- a/grayskull/config.py
+++ b/grayskull/config.py
@@ -40,6 +40,7 @@ class Configuration:
     local_sdist: Optional[str] = None
     missing_deps: set = field(default_factory=set)
     extras_require_test: Optional[str] = None
+    github_release_tag: Optional[str] = None
 
     def get_oldest_py3_version(self, list_py_ver: List[PyVer]) -> PyVer:
         list_py_ver = sorted(list_py_ver)

--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -219,7 +219,10 @@ def get_origin_wise_metadata(config):
         sdist_metadata["version"] = version
         pypi_metadata = {}
     elif config.from_local_sdist:
-        sdist_metadata = get_sdist_metadata(sdist_url="", config=config,)
+        sdist_metadata = get_sdist_metadata(
+            sdist_url="",
+            config=config,
+        )
         pypi_metadata = {}
     else:
         pypi_metadata = get_pypi_metadata(config)

--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -210,7 +210,7 @@ def get_origin_wise_metadata(config):
         url = config.repo_github
         name = config.name
         version, version_tag = handle_gh_version(
-            name=name, version=config.version, url=url
+            name=name, version=config.version, url=url, tag=config.github_release_tag
         )
         archive_url = generate_git_archive_tarball_url(git_url=url, git_ref=version_tag)
         sdist_metadata = get_sdist_metadata(
@@ -219,10 +219,7 @@ def get_origin_wise_metadata(config):
         sdist_metadata["version"] = version
         pypi_metadata = {}
     elif config.from_local_sdist:
-        sdist_metadata = get_sdist_metadata(
-            sdist_url="",
-            config=config,
-        )
+        sdist_metadata = get_sdist_metadata(sdist_url="", config=config,)
         pypi_metadata = {}
     else:
         pypi_metadata = get_pypi_metadata(config)

--- a/tests/cli/test_cli_cmds.py
+++ b/tests/cli/test_cli_cmds.py
@@ -80,6 +80,7 @@ def test_change_pypi_url(mocker):
         sections_populate=None,
         from_local_sdist=False,
         extras_require_test=None,
+        github_release_tag=None,
     )
 
 


### PR DESCRIPTION
Addresses #320 

Hi - I overlooked a contributing.md or the like, so apologies if this isn't in the right place.
I wanted to give the git tags issue a whirl as an intro to this fun project

What this does:
adds a --tag (-t) cli addition for the pypi strategy that then propagates that 'tag' through config and into a new 'verify_github_repo_tag()' in base/github.py when a supplied tag shows up not-None in handle_gh_version()
the verify function looks now at f"/repos{url_parts.path}/git/refs/tags/{tag}" to see if a supplied tag exists - 
if it does exist/match it sets that as version_tag and version in handle_gh_version()

I wasn't certain if this covered the issue, or if the python version identifier also needed to be updated - would appreciate the review; thanks in advance.