### PR TITLE
Tests need setuptools-scm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
             "pytest-cov",
             "pytest-console-scripts",
             "pytest-mock",
+            "setuptools-scm",
         ]
     },
     url="https://github.com/conda-incubator/grayskull",


### PR DESCRIPTION
Closes #361 

This fails on test `test_compose_test_section_with_console_scripts`

```
pytest tests/test_pypi.py
```

The issue is solved by doing

```
pip install setuptools-scm
```

In this MR we add `setuptools-scm` to the test requirements.