### PR TITLE
Use "compatible release" operator ~=

### DIFF
--- a/grayskull/strategy/py_base.py
+++ b/grayskull/strategy/py_base.py
@@ -726,13 +726,6 @@ def ensure_pep440(pkg: str) -> str:
         return pkg
     constrain_pkg = "".join(split_pkg[1:])
     list_constrains = constrain_pkg.split(",")
-    full_constrain = []
-    for constrain in list_constrains:
-        if "~=" in constrain:
-            version = constrain.strip().replace("~=", "").strip()
-            version_reduced = ".".join(version.split(".")[:-1]) + ".*"
-            full_constrain.append(f">={version},=={version_reduced}")
-        else:
-            full_constrain.append(constrain.strip())
+    full_constrain = [constrain.strip() for constrain in list_constrains]
     all_constrains = ",".join(full_constrain)
     return f"{split_pkg[0]} {all_constrains}"

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -423,7 +423,7 @@ def test_normalize_requirements_list():
     config = Configuration(name="pytest")
     requirements = ["pytest ~=5.3.2", "pyqt5"]
     requirements = set(normalize_requirements_list(requirements, config))
-    expected = {"pytest >=5.3.2,==5.3.*", "pyqt"}
+    expected = {"pytest ~=5.3.2", "pyqt"}
     assert requirements == expected
 
 
@@ -1170,7 +1170,7 @@ def test_get_test_imports_clean_modules():
 
 
 def test_ensure_pep440():
-    assert ensure_pep440("pytest ~=5.3.2") == "pytest >=5.3.2,==5.3.*"
+    assert ensure_pep440("pytest ~=5.3.2") == "pytest ~=5.3.2"
 
 
 def test_pep440_recipe():
@@ -1180,7 +1180,7 @@ def test_pep440_recipe():
 
 def test_pep440_in_recipe_pypi():
     recipe = create_python_recipe("kedro=0.17.6", is_strict_cf=False)[0]
-    assert sorted(recipe["requirements"]["run"])[0] == "anyconfig >=0.10.0,==0.10.*"
+    assert sorted(recipe["requirements"]["run"])[0] == "anyconfig ~=0.10.0"
 
 
 def test_create_recipe_from_local_sdist(pkg_pytest):


### PR DESCRIPTION
Building such recipes requires conda-build >=3.20.5

Closes #348