### PR TITLE
Fix "compatible release" operator

### DIFF
--- a/grayskull/strategy/py_base.py
+++ b/grayskull/strategy/py_base.py
@@ -753,4 +753,4 @@ def next_incompatible_version(version: str) -> str:
         )
     release = previous_release[:-2] + (previous_release[-2] + 1,)
     release_str = ".".join(str(r) for r in release)
-    return canonicalize_version(f"{epoch}!{release_str}a")
+    return canonicalize_version(f"{epoch}!{release_str}dev")

--- a/grayskull/strategy/py_base.py
+++ b/grayskull/strategy/py_base.py
@@ -726,6 +726,13 @@ def ensure_pep440(pkg: str) -> str:
         return pkg
     constrain_pkg = "".join(split_pkg[1:])
     list_constrains = constrain_pkg.split(",")
-    full_constrain = [constrain.strip() for constrain in list_constrains]
+    full_constrain = []
+    for constrain in list_constrains:
+        if "~=" in constrain:
+            version = constrain.strip().replace("~=", "").strip()
+            version_reduced = ".".join(version.split(".")[:-1]) + ".*"
+            full_constrain.append(f">={version},=={version_reduced}")
+        else:
+            full_constrain.append(constrain.strip())
     all_constrains = ",".join(full_constrain)
     return f"{split_pkg[0]} {all_constrains}"

--- a/grayskull/strategy/py_base.py
+++ b/grayskull/strategy/py_base.py
@@ -15,6 +15,8 @@ from urllib.parse import urlparse
 import requests
 import tomli
 from colorama import Fore, Style
+from packaging.utils import canonicalize_version
+from packaging.version import Version
 from pkginfo import UnpackedSDist
 
 from grayskull.cli.stdout import manage_progressbar, print_msg
@@ -730,9 +732,25 @@ def ensure_pep440(pkg: str) -> str:
     for constrain in list_constrains:
         if "~=" in constrain:
             version = constrain.strip().replace("~=", "").strip()
-            version_reduced = ".".join(version.split(".")[:-1]) + ".*"
-            full_constrain.append(f">={version},=={version_reduced}")
+            version_upper = next_incompatible_version(version)
+            full_constrain.append(f">={version},<{version_upper}")
         else:
             full_constrain.append(constrain.strip())
     all_constrains = ",".join(full_constrain)
     return f"{split_pkg[0]} {all_constrains}"
+
+
+def next_incompatible_version(version: str) -> str:
+    """Return the next incompatible version for the given version."""
+    comments_removed = version.split("#")[0]
+    version_ = Version(comments_removed)
+    epoch = version_.epoch
+    previous_release = version_.release
+    if len(previous_release) < 2:
+        raise ValueError(
+            f"~= operator requires at least two version numbers, but given only "
+            f"'{version}'"
+        )
+    release = previous_release[:-2] + (previous_release[-2] + 1,)
+    release_str = ".".join(str(r) for r in release)
+    return canonicalize_version(f"{epoch}!{release_str}a")

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "colorama",
         "conda-souschef >=2.2.1",
         "pkginfo",
+        "packaging >=21.3",
         "tomli",
         "tomli-w",
     ],

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -423,7 +423,7 @@ def test_normalize_requirements_list():
     config = Configuration(name="pytest")
     requirements = ["pytest ~=5.3.2", "pyqt5"]
     requirements = set(normalize_requirements_list(requirements, config))
-    expected = {"pytest >=5.3.2,==5.3.*", "pyqt"}
+    expected = {"pytest >=5.3.2,<5.4a0", "pyqt"}
     assert requirements == expected
 
 
@@ -1170,7 +1170,7 @@ def test_get_test_imports_clean_modules():
 
 
 def test_ensure_pep440():
-    assert ensure_pep440("pytest ~=5.3.2") == "pytest >=5.3.2,==5.3.*"
+    assert ensure_pep440("pytest ~=5.3.2") == "pytest >=5.3.2,<5.4a0"
 
 
 def test_pep440_recipe():
@@ -1180,7 +1180,7 @@ def test_pep440_recipe():
 
 def test_pep440_in_recipe_pypi():
     recipe = create_python_recipe("kedro=0.17.6", is_strict_cf=False)[0]
-    assert sorted(recipe["requirements"]["run"])[0] == "anyconfig >=0.10.0,==0.10.*"
+    assert sorted(recipe["requirements"]["run"])[0] == "anyconfig >=0.10.0,<0.11a0"
 
 
 def test_create_recipe_from_local_sdist(pkg_pytest):

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -423,7 +423,7 @@ def test_normalize_requirements_list():
     config = Configuration(name="pytest")
     requirements = ["pytest ~=5.3.2", "pyqt5"]
     requirements = set(normalize_requirements_list(requirements, config))
-    expected = {"pytest >=5.3.2,<5.4a0", "pyqt"}
+    expected = {"pytest >=5.3.2,<5.4.dev0", "pyqt"}
     assert requirements == expected
 
 
@@ -1170,7 +1170,7 @@ def test_get_test_imports_clean_modules():
 
 
 def test_ensure_pep440():
-    assert ensure_pep440("pytest ~=5.3.2") == "pytest >=5.3.2,<5.4a0"
+    assert ensure_pep440("pytest ~=5.3.2") == "pytest >=5.3.2,<5.4.dev0"
 
 
 def test_pep440_recipe():
@@ -1180,7 +1180,7 @@ def test_pep440_recipe():
 
 def test_pep440_in_recipe_pypi():
     recipe = create_python_recipe("kedro=0.17.6", is_strict_cf=False)[0]
-    assert sorted(recipe["requirements"]["run"])[0] == "anyconfig >=0.10.0,<0.11a0"
+    assert sorted(recipe["requirements"]["run"])[0] == "anyconfig >=0.10.0,<0.11.dev0"
 
 
 def test_create_recipe_from_local_sdist(pkg_pytest):

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -423,7 +423,7 @@ def test_normalize_requirements_list():
     config = Configuration(name="pytest")
     requirements = ["pytest ~=5.3.2", "pyqt5"]
     requirements = set(normalize_requirements_list(requirements, config))
-    expected = {"pytest ~=5.3.2", "pyqt"}
+    expected = {"pytest >=5.3.2,==5.3.*", "pyqt"}
     assert requirements == expected
 
 
@@ -1170,7 +1170,7 @@ def test_get_test_imports_clean_modules():
 
 
 def test_ensure_pep440():
-    assert ensure_pep440("pytest ~=5.3.2") == "pytest ~=5.3.2"
+    assert ensure_pep440("pytest ~=5.3.2") == "pytest >=5.3.2,==5.3.*"
 
 
 def test_pep440_recipe():
@@ -1180,7 +1180,7 @@ def test_pep440_recipe():
 
 def test_pep440_in_recipe_pypi():
     recipe = create_python_recipe("kedro=0.17.6", is_strict_cf=False)[0]
-    assert sorted(recipe["requirements"]["run"])[0] == "anyconfig ~=0.10.0"
+    assert sorted(recipe["requirements"]["run"])[0] == "anyconfig >=0.10.0,==0.10.*"
 
 
 def test_create_recipe_from_local_sdist(pkg_pytest):


### PR DESCRIPTION
According to https://github.com/conda-incubator/grayskull/issues/348#issuecomment-1210348234, the currently-merged solution will break back-compatibility. Let's implement another solution instead.

(Hopefully I can take care of it this evening.)