### PR TITLE
Make rm_duplicated_deps robust to mixed dashes and underscores

### DIFF
--- a/grayskull/utils.py
+++ b/grayskull/utils.py
@@ -119,14 +119,18 @@ def rm_duplicated_deps(all_requirements: Union[list, set, None]) -> Optional[lis
     if not all_requirements:
         return None
     new_value = []
+
+    # Keep track of requirements which have already been added to the list.
+    # Here we store a canonicalized version of the requirement: lowercase,
+    # and underscores converted to dashes.
+    added_reqs = set()
+
     for dep in all_requirements:
-        if (
-            dep in new_value
-            or dep.replace("-", "_") in new_value
-            or dep.replace("_", "-") in new_value
-        ):
+        canonicalized = dep.replace("_", "-").lower()
+        if canonicalized in added_reqs:
             continue
         new_value.append(dep)
+        added_reqs.add(canonicalized)
     return new_value
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ from grayskull.utils import (
     merge_dict_of_lists_item,
     merge_list_item,
     origin_is_local_sdist,
+    rm_duplicated_deps,
 )
 
 
@@ -118,3 +119,8 @@ def test_merge_dict_of_lists_item():
             sub_key: set(lst) for sub_key, lst in destination[key].items()
         }
     assert destination == {"name": {"sub_name": {1, 2}}}
+
+
+def test_rm_duplicated_deps():
+    assert rm_duplicated_deps([]) is None
+    assert rm_duplicated_deps(["my_craZy-pkg", "my-crazy-pkg"]) == ["my_craZy-pkg"]


### PR DESCRIPTION
This fixes a fairly obscure edge case, and I don't have any real instances in mind, but I added a test case which would otherwise fail.

(Previously, with input `["my_craZy-pkg", "my-crazy-pkg"]`, the second package is not recognized as duplicate since it only checks the previous entries for `my-crazy-pkg` and `my_crazy_pkg`.)