### PR TITLE
Place Python at the top of requirements lists

### DIFF
--- a/grayskull/cli/stdout.py
+++ b/grayskull/cli/stdout.py
@@ -94,13 +94,13 @@ def print_requirements(
         print_msg(f"{key.capitalize()} requirements:")
         req_list = requirements.get(key, [])
         if req_list:
-            print_req(sorted(req_list))
+            print_req(req_list)
         else:
             print_msg("  <none>")
 
     for key, req_list in optional_requirements.items():
         print_msg(f"{key.capitalize()} requirements (optional):")
-        print_req(sorted(req_list))
+        print_req(req_list)
 
     print_msg(f"\n{Fore.RED}RED{Style.RESET_ALL}: Missing packages")
     print_msg(f"{Fore.GREEN}GREEN{Style.RESET_ALL}: Packages available on conda-forge")

--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -530,17 +530,22 @@ def extract_requirements(metadata: dict, config, recipe) -> Dict[str, List[str]]
     result = {}
     if build_req:
         result = {
-            "build": rm_duplicated_deps(sorted(map(lambda x: x.lower(), build_req)))
+            "build": rm_duplicated_deps(sort_reqs(map(lambda x: x.lower(), build_req)))
         }
 
     result.update(
         {
-            "host": rm_duplicated_deps(sorted(map(lambda x: x.lower(), host_req))),
-            "run": rm_duplicated_deps(sorted(map(lambda x: x.lower(), run_req))),
+            "host": rm_duplicated_deps(sort_reqs(map(lambda x: x.lower(), host_req))),
+            "run": rm_duplicated_deps(sort_reqs(map(lambda x: x.lower(), run_req))),
         }
     )
     update_requirements_with_pin(result)
     return result
+
+
+def sort_reqs(reqs: List[str]) -> List[str]:
+    """Sort requirements."""
+    return sorted(reqs)
 
 
 def remove_selectors_pkgs_if_needed(

--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -4,7 +4,7 @@ import os
 import re
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import Dict, List, Optional
+from typing import Dict, Iterable, List, Optional
 
 import requests
 from colorama import Fore
@@ -543,11 +543,13 @@ def extract_requirements(metadata: dict, config, recipe) -> Dict[str, List[str]]
     return result
 
 
-def sort_reqs(reqs: List[str]) -> List[str]:
+def sort_reqs(reqs: Iterable[str]) -> List[str]:
     """Sort requirements."""
-    python_reqs = [req for req in reqs if req.startswith("python ")]
-    non_python_reqs = [req for req in reqs if not req.startswith("python ")]
-    return python_reqs + sorted(non_python_reqs)
+    reqs_list = list(reqs)
+    python_reqs = [req for req in reqs_list if req.startswith("python ")]
+    non_python_reqs = [req for req in reqs_list if not req.startswith("python ")]
+    result = python_reqs + sorted(non_python_reqs)
+    return result
 
 
 def remove_selectors_pkgs_if_needed(

--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -544,10 +544,14 @@ def extract_requirements(metadata: dict, config, recipe) -> Dict[str, List[str]]
 
 
 def sort_reqs(reqs: Iterable[str]) -> List[str]:
-    """Sort requirements."""
+    """Sort requirements. Put python first, then sort alphabetically."""
     reqs_list = list(reqs)
-    python_reqs = [req for req in reqs_list if req.startswith("python ")]
-    non_python_reqs = [req for req in reqs_list if not req.startswith("python ")]
+
+    def is_python(req: str) -> bool:
+        return req == "python" or req.startswith("python ")
+
+    python_reqs = [req for req in reqs_list if is_python(req)]
+    non_python_reqs = [req for req in reqs_list if not is_python(req)]
     result = python_reqs + sorted(non_python_reqs)
     return result
 

--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -545,7 +545,9 @@ def extract_requirements(metadata: dict, config, recipe) -> Dict[str, List[str]]
 
 def sort_reqs(reqs: List[str]) -> List[str]:
     """Sort requirements."""
-    return sorted(reqs)
+    python_reqs = [req for req in reqs if req.startswith("python ")]
+    non_python_reqs = [req for req in reqs if not req.startswith("python ")]
+    return python_reqs + sorted(non_python_reqs)
 
 
 def remove_selectors_pkgs_if_needed(

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -43,6 +43,7 @@ from grayskull.strategy.pypi import (
     merge_pypi_sdist_metadata,
     normalize_requirements_list,
     remove_selectors_pkgs_if_needed,
+    sort_reqs,
 )
 from grayskull.utils import PyVer, format_dependencies, generate_recipe
 
@@ -1296,3 +1297,16 @@ def test_cpp_language_extra():
         "<{ compiler('cxx') }}",
         "<{ compiler('c') }}",
     }
+
+
+def test_sort_reqs():
+    assert sort_reqs(["pandas >=1.0", "numpy", "python"]) == [
+        "python",
+        "numpy",
+        "pandas >=1.0",
+    ]
+    assert sort_reqs(["pandas >=1.0", "numpy", "python >=3.8"]) == [
+        "python >=3.8",
+        "numpy",
+        "pandas >=1.0",
+    ]

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -798,7 +798,7 @@ def test_cythongsl_recipe_build():
     )
 
     assert recipe["requirements"]["build"] == ["<{ compiler('c') }}"]
-    assert recipe["requirements"]["host"] == ["cython >=0.16", "pip", "python"]
+    assert recipe["requirements"]["host"] == ["python", "cython >=0.16", "pip"]
     assert recipe["build"]["noarch"] is None
     assert recipe["build"]["number"] == 0
 
@@ -822,8 +822,8 @@ def test_zipp_recipe_tags_on_deps():
     recipe = GrayskullFactory.create_recipe("pypi", config)
     assert recipe["build"]["noarch"]
     assert recipe["requirements"]["host"] == [
-        "pip",
         "python >=3.6",
+        "pip",
         "setuptools-scm >=3.4.1",
     ]
 
@@ -973,9 +973,9 @@ def test_deps_comments():
     config = Configuration(name="kubernetes_asyncio", version="11.2.0")
     recipe = GrayskullFactory.create_recipe("pypi", config)
     assert recipe["requirements"]["run"] == [
+        "python",
         "aiohttp >=2.3.10,<4.0.0",
         "certifi >=14.05.14",
-        "python",
         "python-dateutil >=2.5.3",
         "pyyaml >=3.12",
         "setuptools >=21.0.0",
@@ -1013,15 +1013,15 @@ def test_multiples_exit_setup():
 def test_sequence_inside_another_in_dependencies():
     recipe = create_python_recipe("unittest2=1.1.0", is_strict_cf=True)[0]
     assert recipe["requirements"]["host"] == [
+        "python >=3.6",
         "argparse",
         "pip",
-        "python >=3.6",
         "six >=1.4",
         "traceback2",
     ]
     assert recipe["requirements"]["run"] == [
-        "argparse",
         "python >=3.6",
+        "argparse",
         "six >=1.4",
         "traceback2",
     ]
@@ -1135,7 +1135,7 @@ def test_replace_slash_in_imports():
 def test_add_python_min_to_strict_conda_forge():
     recipe = create_python_recipe("dgllife=0.2.8", is_strict_cf=True)[0]
     assert recipe["build"]["noarch"] == "python"
-    assert recipe["requirements"]["host"][1] == "python >=3.6"
+    assert recipe["requirements"]["host"][0] == "python >=3.6"
     assert "python >=3.6" in recipe["requirements"]["run"]
 
 
@@ -1177,7 +1177,7 @@ def test_ensure_pep440():
 
 def test_pep440_recipe():
     recipe = create_python_recipe("codalab=0.5.26", is_strict_cf=False)[0]
-    assert recipe["requirements"]["host"] == ["pip", "python >=3.6"]
+    assert recipe["requirements"]["host"] == ["python >=3.6", "pip"]
 
 
 def test_pep440_in_recipe_pypi():


### PR DESCRIPTION
Currently, all requirements are sorted in alphabetical order.

I personally have a strong aesthetic preference for putting the `python` requirement up top, with the sorted package requirements below.

In case others share my preference, here's an implementation.