### PR TITLE
Fix scrambled dependency order

### DIFF
--- a/grayskull/utils.py
+++ b/grayskull/utils.py
@@ -237,6 +237,11 @@ def _clean_yaml(recipe, all_obj_to_delete=None):
 
 
 def merge_list_item(destination: dict, add: dict, key: str) -> None:
+    """Modify the list 'destination[key]' to include missing elements from 'add[key]'.
+
+    Duplicated elements are removed. The order of the elements is preserved.
+    In case 'key' is undefined or empty in both lists, 'destination' is unmodified.
+    """
     result = []
     destination_list = destination.get(key, [])
     add_list = add.get(key, [])

--- a/grayskull/utils.py
+++ b/grayskull/utils.py
@@ -237,10 +237,14 @@ def _clean_yaml(recipe, all_obj_to_delete=None):
 
 
 def merge_list_item(destination: dict, add: dict, key: str) -> None:
-    lst = set(destination.get(key, []))
-    lst |= set(add.get(key, []))
-    if lst:
-        destination[key] = list(lst)
+    result = []
+    destination_list = destination.get(key, [])
+    add_list = add.get(key, [])
+    for item in destination_list + add_list:
+        if item not in result:
+            result.append(item)
+    if len(result) > 0:
+        destination[key] = result
 
 
 def merge_dict_of_lists_item(destination: dict, add: dict, key: str) -> None:


### PR DESCRIPTION
The order of dependencies is being randomized because a list is being converted to a set and back. This fixes that.