### PR TITLE
Fix issue 388

### DIFF
--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -421,7 +421,9 @@ def get_metadata(recipe, config) -> dict:
             for option, req_list in optional_requirements.items():
                 req_section = dict(output_req_section)
                 req_section["run"] = list(req_section["run"])
-                req_section["run"].append(f"{name} =={{{{ version }}}}")
+                req_section["run"].append(
+                    f"{{{{ pin_subpackage('{name}', exact=True) }}}}"
+                )
                 req_section["run"].extend(req_list)
                 output = {
                     "name": f"{name}-{option}",

--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -408,30 +408,28 @@ def get_metadata(recipe, config) -> dict:
     outputs = []
     if optional_requirements:
         if config.extras_require_split:
+            # First output is the package itself. Inherits all top-level
+            # recipe sections like 'requirements', 'build', 'test'.
+            outputs.append({"name": name})
+
+            # Other outputs are empty and only add extra dependencies. Does
+            # not inherit any top-level section.
             output_req_section = dict(requirements_section)
-            requirements_section = {
-                k: v for k, v in requirements_section.items() if k == "host"
-            }
-            outputs.append(
-                {
-                    "name": name,
-                    "requirements": dict(output_req_section),
-                }
-            )
             output_req_section["run"] = [
-                s for s in output_req_section["run"] if "python" in s
+                s for s in output_req_section.get("run", []) if "python" in s
             ]
             for option, req_list in optional_requirements.items():
                 req_section = dict(output_req_section)
-                req_section["run"] = list(req_section.get("run", list()))
+                req_section["run"] = list(req_section["run"])
                 req_section["run"].append(f"{name} =={{{{ version }}}}")
                 req_section["run"].extend(req_list)
-                outputs.append(
-                    {
-                        "name": f"{name}-{option}",
-                        "requirements": req_section,
-                    }
-                )
+                output = {
+                    "name": f"{name}-{option}",
+                    "requirements": req_section,
+                }
+                if test_section:
+                    output["test"] = test_section
+                outputs.append(output)
         else:
             # Sort options in terms of inclusion
             optional_requirements_items = list()
@@ -451,7 +449,7 @@ def get_metadata(recipe, config) -> dict:
                 requirements_section["run"] += [f"# Extra: {option}"] + req_list
 
     if outputs:
-        package_section = {"name": name + "-meta", "version": metadata["version"]}
+        package_section = {"name": name, "version": metadata["version"]}
         return {
             "package": package_section,
             "build": build_section,
@@ -503,6 +501,8 @@ def update_recipe(recipe: Recipe, config: Configuration, all_sections: List[str]
         recipe["build"]["noarch"] = "python"
         if "outputs" in recipe:
             for output in recipe["outputs"]:
+                if output["name"].lower() == config.name.lower():
+                    continue  # inherits top-level sections
                 if "build" not in output:
                     output["build"] = dict()
                 output["build"]["noarch"] = "python"

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -311,7 +311,7 @@ def test_get_include_extra_requirements():
     # extras are not used
     config = Configuration(name="dask", version="2022.6.1")
     recipe = GrayskullFactory.create_recipe("pypi", config)
-    recipe["name"] == "dask"
+    assert recipe["package"]["name"] == "<{ name|lower }}"
     assert set(recipe["outputs"]) == set()
     assert set(recipe["requirements"]["host"]) == set(host_requirements)
     assert set(recipe["requirements"]["run"]) == set(base_requirements)
@@ -320,7 +320,7 @@ def test_get_include_extra_requirements():
     # all extras are included in the requirements
     config = Configuration(name="dask", version="2022.6.1", extras_require_all=True)
     recipe = GrayskullFactory.create_recipe("pypi", config)
-    recipe["name"] == "dask"
+    assert recipe["package"]["name"] == "<{ name|lower }}"
     assert set(recipe["outputs"]) == set()
 
     expected = list(base_requirements)
@@ -341,7 +341,7 @@ def test_get_include_extra_requirements():
         extras_require_test="test",
     )
     recipe = GrayskullFactory.create_recipe("pypi", config)
-    recipe["name"] == "dask"
+    assert recipe["package"]["name"] == "<{ name|lower }}"
     assert set(recipe["outputs"]) == set()
 
     expected = list(base_requirements)
@@ -358,7 +358,7 @@ def test_get_include_extra_requirements():
         name="dask", version="2022.6.1", extras_require_include=("array",)
     )
     recipe = GrayskullFactory.create_recipe("pypi", config)
-    recipe["name"] == "dask"
+    assert recipe["package"]["name"] == "<{ name|lower }}"
     assert set(recipe["outputs"]) == set()
     assert set(recipe["requirements"]["host"]) == set(host_requirements)
     assert set_of_strings(recipe["requirements"]["run"]) == {
@@ -377,7 +377,7 @@ def test_get_include_extra_requirements():
         extras_require_test="test",
     )
     recipe = GrayskullFactory.create_recipe("pypi", config)
-    recipe["name"] == "dask"
+    assert recipe["package"]["name"] == "<{ name|lower }}"
     assert set(recipe["outputs"]) == set()
     assert set(recipe["requirements"]["host"]) == set(host_requirements)
     assert set_of_strings(recipe["requirements"]["run"]) == set(base_requirements)
@@ -393,7 +393,7 @@ def test_get_include_extra_requirements():
         extras_require_split=True,
     )
     recipe = GrayskullFactory.create_recipe("pypi", config)
-    recipe["name"] == "dask"
+    assert recipe["package"]["name"] == "<{ name|lower }}"
     assert set(recipe["outputs"]) == set()
     assert set(recipe["requirements"]["host"]) == set(host_requirements)
     assert set_of_strings(recipe["requirements"]["run"]) == set(base_requirements)
@@ -409,13 +409,12 @@ def test_get_include_extra_requirements():
         extras_require_split=True,
     )
     recipe = GrayskullFactory.create_recipe("pypi", config)
-    recipe["name"] == "dask-meta"
+    assert recipe["package"]["name"] == "<{ name|lower }}"
     assert set(recipe["requirements"]["host"]) == set(host_requirements)
-    assert not recipe["requirements"]["run"]
+    assert set(recipe["requirements"]["run"]) == set(base_requirements)
     assert len(recipe["outputs"]) == 6
 
     expected = dict()
-    expected["dask"] = set(base_requirements)
     for name, req_lst in extras.items():
         if name != "test":
             expected[f"dask-{name}"] = {
@@ -425,10 +424,27 @@ def test_get_include_extra_requirements():
             }
     found = dict()
     for output in recipe["outputs"]:
-        found[output["name"]] = set_of_strings(output["requirements"]["run"])
+        if output["name"] == "dask":
+            assert "requirements" not in output
+        else:
+            assert set(output["requirements"]["host"]) == set(host_requirements)
+            found[output["name"]] = set_of_strings(output["requirements"]["run"])
     assert found == expected
 
-    assert set_of_strings(recipe["test"]["requires"]) == {"pip", *extras["test"]}
+    expected = {"pip", *extras["test"]}
+    assert set_of_strings(recipe["test"]["requires"]) == expected
+    for output in recipe["outputs"]:
+        if output["name"] == "dask":
+            assert "test" not in output
+        else:
+            assert set_of_strings(output["test"]["requires"]) == expected
+
+    expected = {"noarch": "python"}
+    for output in recipe["outputs"]:
+        if output["name"] == "dask":
+            assert "build" not in output
+        else:
+            assert output["build"] == expected
 
 
 def test_normalize_requirements_list():

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -418,7 +418,7 @@ def test_get_include_extra_requirements():
     for name, req_lst in extras.items():
         if name != "test":
             expected[f"dask-{name}"] = {
-                "dask =={{ version }}",
+                "{{ pin_subpackage('dask', exact=True) }}",
                 "python >=3.8",
                 *req_lst,
             }


### PR DESCRIPTION
Closes #388

Handle pip extra's as follows:

```
package:
    name: mypackage
    ....

requirements:
    ....

build:
    ....

test:
    ....

outputs:
    - name: mypackage
    - name: mypackage-option1
        - requirements:
              pypushflow =={{ version }}
              ....
        - test:
              ....
        - build:
            - noarch
    - name: mypackage-option2
        - requirements:
              pypushflow =={{ version }}
              ....
        - test:
              ....
        - build:
            - noarch
```

The `mypackage` inherits all top-level sections (requirements, build, test) and will contain the actual distribution.

The `mypackage-option1` and `mypackage-option2` outputs do NOT inherit top-level sections (although package version and build number seem to be inherited). The build does not contain a script so these conda packages will only add extra requirements (which is the goal).