### PR TITLE
squeeze out None licenses

### DIFF
--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -362,6 +362,7 @@ def get_metadata(recipe, config) -> dict:
         print_msg(f"License type: {Fore.LIGHTMAGENTA_EX}{license_metadata.name}")
         print_msg(f"License file: {Fore.LIGHTMAGENTA_EX}{license_file}")
     if all_license_name:
+        all_license_name = list(filter(None, all_license_name))
         license_name = " & ".join(all_license_name)
         if len(all_license_name) > 1:
             print_msg(


### PR DESCRIPTION
Grayskull crashes when one of the licenses is None in the `all_license_name` list. This is probably not the best solution but I thought I should try a PR instead of just opening issues ;-p