### PR TITLE
add scikit-learn to name mapping

### DIFF
--- a/grayskull/strategy/config.yaml
+++ b/grayskull/strategy/config.yaml
@@ -455,3 +455,7 @@ exceptiongroup:
   conda_forge: exceptiongroup
   import_name: exceptiongroup
   avoid_selector: true
+
+scikit-learn:
+  conda_forge: scikit-learn
+  import_name: sklearn


### PR DESCRIPTION
Folks can declare either scikit-learn or sklearn on requriements.txt. I did not fix the final name in the recipe yet. Trying to figure out where that goes.

Using `grayskull pypi --strict-conda-forge pymyami` to test this out.