### PR TITLE
Add a quirk for `google-cloud-bigquery`

### DIFF
--- a/grayskull/strategy/config.yaml
+++ b/grayskull/strategy/config.yaml
@@ -154,6 +154,10 @@ google:
   conda_forge: googlesearch
   import_name: googlesearch
 
+google-cloud-bigquery:
+  conda_forge: google-cloud-bigquery-core
+  import_name: google.cloud.bigquery
+
 graphviz:
   import_name: graphviz
   conda_forge: python-graphviz


### PR DESCRIPTION
On conda-forge, the package `google-cloud-bigquery` is quite bloated because it contains all the extras.  The pypi package `google-cloud-bigquery` is instead `google-cloud-bigquery-core` on conda-forge:

https://github.com/conda-forge/google-cloud-bigquery-feedstock/blob/main/recipe/meta.yaml#L70