### PR TITLE
Do not pkg tests as a module

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,6 @@ exclude .pre-commit-config.yaml
 exclude .flake8
 exclude .coveragerc
 exclude .isort.cfg
-exclude tests/
+prune tests/
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ else:
 
 setup(
     name="grayskull",
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests",)),
     entry_points={
         "console_scripts": [
             "grayskull = grayskull.__main__:main",


### PR DESCRIPTION
Just installed grayskull into a fresh env and got the test module clobber warning. I'm investigating who was the first culprit to write those there but grayskull was the second one ;-p