### PR TITLE
Ignore licenses in hidden directories

### DIFF
--- a/grayskull/license/discovery.py
+++ b/grayskull/license/discovery.py
@@ -270,7 +270,7 @@ def _get_api_github_url(github_url: str, version: Optional[str] = None) -> str:
 
 def search_license_folder(
     path: Union[str, Path], default: Optional[str] = None
-) -> Optional[ShortLicense]:
+) -> list[ShortLicense]:
     """Search for the license in the given folder
 
     :param path: Sdist folder
@@ -283,12 +283,11 @@ def search_license_folder(
     )
     all_licences = []
     for folder_path, dirnames, filenames in os.walk(str(path)):
-        if os.path.basename(folder_path).startswith("."):
-            continue
         dirnames[:] = [
             folder
             for folder in dirnames
             if folder not in ("doc", "theme", "themes", "docs")
+            and not folder.startswith(".")
         ]
         for one_file in filenames:
             if re_search.match(one_file):

--- a/grayskull/license/discovery.py
+++ b/grayskull/license/discovery.py
@@ -270,7 +270,7 @@ def _get_api_github_url(github_url: str, version: Optional[str] = None) -> str:
 
 def search_license_folder(
     path: Union[str, Path], default: Optional[str] = None
-) -> list[ShortLicense]:
+) -> List[ShortLicense]:
     """Search for the license in the given folder
 
     :param path: Sdist folder

--- a/tests/license/test_discovery.py
+++ b/tests/license/test_discovery.py
@@ -124,6 +124,21 @@ def test_search_license_folder(pkg_pytest):
     assert license_folder.name == "MIT"
 
 
+def test_search_license_folder_hidden_folder(tmp_path, license_pytest_5_3_1):
+    d = tmp_path / "mypackage"
+    d.mkdir()
+    license_path = d / "LICENSE"
+    license_path.write_text(license_pytest_5_3_1)
+    # Following licences under hidden directory should be ignored
+    egg_info = d / ".eggs" / "setuptools_scm-7.0.5-py3.10.egg" / "EGG-INFO"
+    egg_info.mkdir(parents=True)
+    for lic in (d / ".eggs" / "LICENSE", egg_info / "LICENSE"):
+        lic.write_text(license_pytest_5_3_1)
+    all_licenses = search_license_folder(tmp_path)
+    assert len(all_licenses) == 1
+    assert all_licenses[0].path == str(license_path)
+
+
 @pytest.mark.xfail(
     reason="This test may fail because github has limitation regarding the"
     " number of requisitions we can do to their api."


### PR DESCRIPTION
When searching for licenses, files in hidden directories (like .eggs/LICENSE) were excluded but not the directories under (.eggs/foo/)..

Don't just hope over hidden directories but remove them from the list of directories to search.

Fix #398