### PR TITLE
Add importlib-metadata to avoid_selector

### DIFF
--- a/grayskull/strategy/config.yaml
+++ b/grayskull/strategy/config.yaml
@@ -467,3 +467,8 @@ exceptiongroup:
 scikit-learn:
   conda_forge: scikit-learn
   import_name: sklearn
+
+importlib-metadata:
+  conda-forge: importlib-metadata
+  import_name: importlib-metadata
+  avoid_selector: true


### PR DESCRIPTION
At some point, we should still continue the discussion in https://github.com/conda-forge/conda-forge.github.io/pull/1615 and https://github.com/conda-incubator/grayskull/issues/216

Ref: https://conda-forge.org/docs/maintainer/knowledge_base.html#non-version-specific-python-packages